### PR TITLE
Make conversion functions use ParserSyntaxError

### DIFF
--- a/libcst/_parser/_conversions/expression.py
+++ b/libcst/_parser/_conversions/expression.py
@@ -11,6 +11,7 @@ from tokenize import (
     Intnumber as INTNUMBER_RE,
 )
 
+from libcst._exceptions import ParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import (
     Arg,
@@ -400,7 +401,7 @@ def convert_comp_op(
                 ),
             )
         else:
-            # TODO: Make this a ParserSyntaxError
+            # this should be unreachable
             raise Exception(f"Unexpected token '{op.string}'!")
     else:
         # A two-token comparison
@@ -431,7 +432,7 @@ def convert_comp_op(
                 ),
             )
         else:
-            # TODO: Make this a ParserSyntaxError
+            # this should be unreachable
             raise Exception(f"Unexpected token '{leftcomp.string} {rightcomp.string}'!")
 
 
@@ -1247,8 +1248,10 @@ def _convert_dict(
         possible_comp_for = None if len(children) < 4 else children[3]
     if isinstance(possible_comp_for, CompFor):
         if is_first_starred:
-            # TODO: Make this a ParserSyntaxError
-            raise Exception("dict unpacking cannot be used in dict comprehension")
+            raise ParserSyntaxError(
+                "dict unpacking cannot be used in dict comprehension",
+                lines=config.lines,
+            )
         return _convert_dict_comp(config, children)
 
     children_iter = iter(children)

--- a/libcst/_parser/_conversions/params.py
+++ b/libcst/_parser/_conversions/params.py
@@ -5,6 +5,7 @@
 
 from typing import Any, List, Optional, Sequence, Union
 
+from libcst._exceptions import ParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import Annotation, Name, Param, Parameters, ParamStar
 from libcst._nodes._op import AssignEqual, Comma
@@ -50,8 +51,13 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 star_arg = param
                 current_param = kwonly_params
             else:
-                # TODO: We need to inform the user of an invalid syntax here
-                raise Exception("Syntax error!")
+                # Example code:
+                #     def fn(*abc, *): ...
+                # This should be unreachable, the grammar already disallows it.
+                raise Exception(
+                    "Cannot have multiple star ('*') markers in a single argument "
+                    + "list.",
+                )
         elif isinstance(param.star, str) and param.star == "" and param.default is None:
             # Can only add this if we're in the params or kwonly_params section
             if current_param is params:
@@ -59,8 +65,13 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
             elif current_param is kwonly_params:
                 kwonly_params.append(param)
             else:
-                # TODO: We need to inform the user of an invalid syntax here
-                raise Exception("Syntax error!")
+                # Example code:
+                #     def fn(first=None, second): ...
+                # This code is reachable, so we should use a ParserSyntaxError.
+                raise ParserSyntaxError(
+                    "Cannot have a non-default argument following a default argument.",
+                    lines=config.lines,
+                )
         elif (
             isinstance(param.star, str)
             and param.star == ""
@@ -74,8 +85,10 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
             elif current_param is kwonly_params:
                 kwonly_params.append(param)
             else:
-                # TODO: We need to inform the user of an invalid syntax here
-                raise Exception("Syntax error!")
+                # Example code:
+                #     def fn(**kwargs, trailing=None)
+                # This should be unreachable, the grammar already disallows it.
+                raise Exception("Cannot have any arguments after a kwargs expansion.")
         elif (
             isinstance(param.star, str) and param.star == "*" and param.default is None
         ):
@@ -85,8 +98,13 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 star_arg = param
                 current_param = kwonly_params
             else:
-                # TODO: We need to inform the user of an invalid syntax here
-                raise Exception("Syntax error!")
+                # Example code:
+                #     def fn(*first, *second): ...
+                # This should be unreachable, the grammar already disallows it.
+                raise Exception(
+                    "Expected a keyword argument but found a starred positional "
+                    + "argument expansion."
+                )
         elif (
             isinstance(param.star, str) and param.star == "**" and param.default is None
         ):
@@ -96,11 +114,16 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 star_kwarg = param
                 current_param = None
             else:
-                # TODO: We need to inform the user of an invalid syntax here
-                raise Exception("Syntax error!")
+                # Example code:
+                #     def fn(**first, **second)
+                # This should be unreachable, the grammar already disallows it.
+                raise Exception(
+                    "Multiple starred keyword argument expansions are not allowed in a "
+                    + "single argument list"
+                )
         else:
-            # TODO: We need to inform the user of an invalid syntax here
-            raise Exception("Syntax error!")
+            # The state machine should never end up here.
+            raise Exception("Logic error!")
 
         return current_param
 
@@ -112,8 +135,18 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
     for parameter, comma in grouper(children, 2):
         if comma is None:
             if isinstance(parameter, ParamStarPartial):
-                # TODO: We need to inform the user of an invalid syntax here
-                raise Exception("Syntax error!")
+                # Example:
+                #     def fn(abc, *): ...
+                #
+                # There's also the case where we have bare * with a trailing comma.
+                # That's handled later.
+                #
+                # It's not valid to construct a ParamStar object without a comma, so we
+                # need to catch the non-comma case separately.
+                raise ParserSyntaxError(
+                    "Named (keyword) arguments must follow a bare *.",
+                    lines=config.lines
+                )
             else:
                 current = add_param(current, parameter)
         else:
@@ -129,6 +162,20 @@ def convert_argslist(config: ParserConfig, children: Sequence[Any]) -> Any:
                 current = add_param(current, ParamStar(comma=comma))
             else:
                 current = add_param(current, parameter.with_changes(comma=comma))
+
+    if isinstance(star_arg, ParamStar) and len(kwonly_params) == 0:
+        # Example:
+        #     def fn(abc, *,): ...
+        #
+        # This will raise a validation error, but we want to make sure to raise a syntax
+        # error instead.
+        #
+        # The case where there's no trailing comma is already handled by this point, so
+        # this conditional is only for the case where we have a trailing comma.
+        raise ParserSyntaxError(
+            "Named (keyword) arguments must follow a bare *.",
+            lines=config.lines
+        )
 
     return Parameters(
         params=tuple(params),

--- a/libcst/_parser/_conversions/statement.py
+++ b/libcst/_parser/_conversions/statement.py
@@ -5,6 +5,7 @@
 
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
+from libcst._exceptions import ParserSyntaxError
 from libcst._maybe_sentinel import MaybeSentinel
 from libcst._nodes._expression import (
     Annotation,
@@ -1173,8 +1174,10 @@ def convert_classdef(config: ParserConfig, children: Sequence[Any]) -> Any:
             if current_arg is keywords and (
                 arg.star == "*" or (arg.star == "" and arg.keyword is None)
             ):
-                # TODO: Need a real syntax error here
-                raise Exception("Syntax error!")
+                raise ParserSyntaxError(
+                    "Positional argument follows keyword argument.",
+                    lines=config.lines,
+                )
             current_arg.append(arg)
 
         return ClassDef(

--- a/libcst/_parser/tests/test_parse_errors.py
+++ b/libcst/_parser/tests/test_parse_errors.py
@@ -96,10 +96,70 @@ class ParseErrorsTest(UnitTest):
                 dedent(
                     """
                     Syntax Error @ 1:19.
-                    Internal error: dict unpacking cannot be used in dict comprehension
+                    dict unpacking cannot be used in dict comprehension
 
                     {**el for el in []}
                                       ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__arglist_non_default_after_default": (
+                lambda: cst.parse_statement("def fn(first=None, second): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 1:26.
+                    Cannot have a non-default argument following a default argument.
+
+                    def fn(first=None, second): ...
+                                             ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__arglist_trailing_param_star_without_comma": (
+                lambda: cst.parse_statement("def fn(abc, *): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 1:14.
+                    Named (keyword) arguments must follow a bare *.
+
+                    def fn(abc, *): ...
+                                 ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__arglist_trailing_param_star_with_comma": (
+                lambda: cst.parse_statement("def fn(abc, *,): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 1:15.
+                    Named (keyword) arguments must follow a bare *.
+
+                    def fn(abc, *,): ...
+                                  ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__class_arg_positional_after_keyword": (
+                lambda: cst.parse_statement("class Cls(first=None, second): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 2:1.
+                    Positional argument follows keyword argument.
+
+                    class Cls(first=None, second): ...
+                                                      ^
+                    """
+                ).strip(),
+            ),
+            "convert_nonterminal__class_arg_positional_expansion_after_keyword": (
+                lambda: cst.parse_statement("class Cls(first=None, *second): ..."),
+                dedent(
+                    """
+                    Syntax Error @ 2:1.
+                    Positional argument follows keyword argument.
+
+                    class Cls(first=None, *second): ...
+                                                       ^
                     """
                 ).strip(),
             ),


### PR DESCRIPTION
## Summary

For anything that's not an internal logic error, conversion functions should raise a ParserSyntaxError.

Internal logic errors should probably use an AssertionError or an assert statement, but that's not as important and is out of scope for this PR.

## Test Plan

Unit tests!